### PR TITLE
Fastapi chat serve

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4274,6 +4274,27 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sse-starlette"
+version = "2.2.1"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99"},
+    {file = "sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.41.3"
+
+[package.extras]
+examples = ["fastapi"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "starlette"
 version = "0.45.3"
 description = "The little ASGI library that shines."
@@ -5125,4 +5146,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "f7c99ed2206c594235c067b0b41e0157e29a2636ec28164ecdef334611461c66"
+content-hash = "56aa6809424cf3bdd794768ea1cddc9d7920310a2c14ff2f59fd3c14dc7c2e7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "mixpanel (>=4.10.1,<5.0.0)",
     "tree-sitter-cpp (>=0.23.4,<0.24.0)",
     "sqlalchemy (>=2.0.38,<3.0.0)",
+    "fastapi (>=0.115.8,<0.116.0)",
+    "sse-starlette (>=2.2.1,<3.0.0)",
     "psycopg2-binary (>=2.9.10,<3.0.0)"
 ]
 

--- a/src/knowlang/api/__init__.py
+++ b/src/knowlang/api/__init__.py
@@ -1,0 +1,5 @@
+from .base import ApiModelRegistry
+
+__all__ = [
+    "ApiModelRegistry"
+]

--- a/src/knowlang/api/base.py
+++ b/src/knowlang/api/base.py
@@ -1,0 +1,44 @@
+from enum import Enum
+from typing import Dict, Type, Union, cast, TypeVar
+from pydantic import BaseModel
+
+# Create type vars for better type hints
+T = TypeVar('T', bound=Union[BaseModel, Enum])
+
+class ApiModelRegistry:
+    """Registry for both Pydantic models and Enums that need OpenAPI schemas"""
+    _schemas: Dict[str, Union[Type[BaseModel], Type[Enum]]] = {}
+    
+    @classmethod
+    def register(cls, schema_type: T) -> T:
+        """Register a model or enum for OpenAPI schema generation"""
+        cls._schemas[schema_type.__name__] = schema_type
+
+        # Use cast to preserve the original type
+        return cast(T, schema_type)
+    
+    @classmethod
+    def get_schema(cls, name: str) -> dict:
+        """Get OpenAPI schema for a registered type"""
+        schema_type = cls._schemas.get(name)
+        if not schema_type:
+            raise ValueError(f"Schema {name} not registered")
+            
+        if issubclass(schema_type, BaseModel):
+            # make it openapi compatible
+            return schema_type.model_json_schema(ref_template="#/components/schemas/{model}")
+        elif issubclass(schema_type, Enum):
+            # Handle Enum schemas differently
+            return {
+                "type": "string",
+                "enum": [e.value for e in schema_type],
+                "title": schema_type.__name__,
+                "description": schema_type.__doc__ or ""
+            }
+        else:
+            raise ValueError(f"Unsupported schema type: {schema_type}")
+
+    @classmethod
+    def get_all_schemas(cls) -> Dict[str, dict]:
+        """Get all registered OpenAPI schemas"""
+        return {name: cls.get_schema(name) for name in cls._schemas}

--- a/src/knowlang/chat_bot/__init__.py
+++ b/src/knowlang/chat_bot/__init__.py
@@ -1,4 +1,4 @@
-from .chat_graph import ChatStatus, stream_chat_progress
+from .chat_graph import ChatStatus, stream_chat_progress, StreamingChatResult
 from .chat_interface import create_chatbot
 from .feedback import ChatAnalytics
 
@@ -6,5 +6,6 @@ __all__ = [
     "ChatStatus",
     "stream_chat_progress",
     "ChatAnalytics",
-    "create_chatbot"
+    "create_chatbot",
+    "StreamingChatResult",
 ]

--- a/src/knowlang/chat_bot/__init__.py
+++ b/src/knowlang/chat_bot/__init__.py
@@ -1,4 +1,9 @@
-from .chat_graph import ChatStatus, stream_chat_progress, StreamingChatResult
+from .chat_graph import (
+    ChatStatus, 
+    stream_chat_progress, 
+    StreamingChatResult, 
+    RetrievedContext
+)
 from .chat_interface import create_chatbot
 from .feedback import ChatAnalytics
 
@@ -8,4 +13,5 @@ __all__ = [
     "ChatAnalytics",
     "create_chatbot",
     "StreamingChatResult",
+    "RetrievedContext",
 ]

--- a/src/knowlang/chat_bot/api.py
+++ b/src/knowlang/chat_bot/api.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+from knowlang.configs import AppConfig
+from knowlang.vector_stores import VectorStoreFactory
+from knowlang.utils import FancyLogger
+from knowlang.chat_bot import (
+    stream_chat_progress, 
+    ChatStatus,
+    ChatAnalytics,
+    StreamingChatResult,
+)
+
+LOG = FancyLogger(__name__)
+
+
+class ServerSentChatEvent(BaseModel):
+    event: ChatStatus
+    data: StreamingChatResult
+
+# Create FastAPI app
+app = FastAPI(title="KnowLang API")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Update this with your frontend origins in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+config = AppConfig()
+# Dependency to get config
+async def get_app_config():
+    return config
+
+# Dependency to get vector store
+async def get_vector_store(config: AppConfig = Depends(get_app_config)):
+    return VectorStoreFactory.get(config.db)
+
+# Dependency to get chat analytics
+async def get_chat_analytics(config: AppConfig = Depends(get_app_config)):
+    return ChatAnalytics(config.chat_analytics)
+
+@app.get("/api/v1/chat/stream")
+async def stream_chat(
+    query: str,
+    config: AppConfig = Depends(get_app_config),
+    vector_store = Depends(get_vector_store),
+    chat_analytics = Depends(get_chat_analytics),
+):
+    """
+    Streaming chat endpoint that uses server-sent events (SSE)
+    """
+    async def event_generator():
+        # Process using the core logic from Gradio
+        async for result in stream_chat_progress(query, vector_store, config):
+            yield ServerSentChatEvent(event=result.status, data=result).model_dump()
+                
+    return EventSourceResponse(event_generator())

--- a/src/knowlang/chat_bot/chat_graph.py
+++ b/src/knowlang/chat_bot/chat_graph.py
@@ -1,27 +1,32 @@
 # __future__ annotations is necessary for the type hints to work in this file
 from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
-
 import logfire
 import voyageai
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_graph import (BaseNode, End, EndStep, Graph, GraphRunContext,
-                            HistoryStep)
+from pydantic_graph import (
+    BaseNode, 
+    End, 
+    EndStep, 
+    Graph, 
+    GraphRunContext,
+    HistoryStep
+)
 from rich.console import Console
 from voyageai.object.reranking import RerankingObject
-
 from knowlang.configs import AppConfig, EmbeddingConfig, RerankerConfig
 from knowlang.models import EmbeddingInputType, generate_embedding
 from knowlang.utils import FancyLogger, create_pydantic_model, truncate_chunk
 from knowlang.vector_stores import SearchResult, VectorStore
+from knowlang.api import ApiModelRegistry
 
 LOG = FancyLogger(__name__)
 console = Console()
 
+@ApiModelRegistry.register
 class ChatStatus(str, Enum):
     """Enum for tracking chat progress status"""
     STARTING = "starting"
@@ -31,6 +36,7 @@ class ChatStatus(str, Enum):
     COMPLETE = "complete"
     ERROR = "error"
 
+@ApiModelRegistry.register
 class StreamingChatResult(BaseModel):
     """Extended chat result with streaming information"""
     answer: str
@@ -87,6 +93,7 @@ class StreamingChatResult(BaseModel):
             progress_message=f"An error occurred: {error_msg}"
         )
 
+@ApiModelRegistry.register
 class RetrievedContext(BaseModel):
     """Structure for retrieved context"""
     chunks: List[str]

--- a/src/knowlang/cli/commands/serve.py
+++ b/src/knowlang/cli/commands/serve.py
@@ -3,7 +3,7 @@ import uvicorn
 from knowlang.cli.types import ServeCommandArgs
 from knowlang.configs import AppConfig
 from knowlang.utils import FancyLogger
-from knowlang.vector_stores import VectorStoreError, VectorStoreFactory
+from knowlang.vector_stores.factory import VectorStoreError, VectorStoreFactory
 
 LOG = FancyLogger(__name__)
 

--- a/src/knowlang/cli/commands/serve.py
+++ b/src/knowlang/cli/commands/serve.py
@@ -1,0 +1,47 @@
+"""Command implementation for the API server interface."""
+import uvicorn
+from knowlang.cli.types import ServeCommandArgs
+from knowlang.configs import AppConfig
+from knowlang.utils import FancyLogger
+from knowlang.vector_stores import VectorStoreError, VectorStoreFactory
+
+LOG = FancyLogger(__name__)
+
+def create_config(args: ServeCommandArgs) -> AppConfig:
+    """Create configuration from file or defaults."""
+    if args.config:
+        with open(args.config, 'r') as file:
+            config_data = file.read()
+            return AppConfig.model_validate_json(config_data)
+    return AppConfig()
+
+async def serve_command(args: ServeCommandArgs) -> None:
+    """Execute the serve command.
+    
+    Args:
+        args: Typed command line arguments
+    """
+    config = create_config(args)
+    
+    # Initialize vector store
+    try:
+        VectorStoreFactory.get(config.db)
+    except VectorStoreError as e:
+        LOG.error(
+            "Vector store initialization failed. Please run 'knowlang parse' first to index your codebase."
+            f"\nError: {str(e)}"
+        )
+        return
+
+    # Configure uvicorn server using Server class directly
+    config = uvicorn.Config(
+        "knowlang.chat_bot.api:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        workers=args.workers,
+    )
+    
+    server = uvicorn.Server(config)
+    # Use await instead of run() to respect the existing event loop
+    await server.serve()

--- a/src/knowlang/cli/types.py
+++ b/src/knowlang/cli/types.py
@@ -24,3 +24,12 @@ class ChatCommandArgs(BaseCommandArgs):
     share: bool = False
     server_port: Optional[int] = None
     server_name: Optional[str] = None
+
+@dataclass
+class ServeCommandArgs(BaseCommandArgs):
+    """Arguments for the serve command."""
+    command: Literal["serve"]
+    host: str = "127.0.0.1"
+    port: int = 8000
+    reload: bool = False
+    workers: int = 1

--- a/tests/api/test_api_model_registry.py
+++ b/tests/api/test_api_model_registry.py
@@ -1,0 +1,121 @@
+import pytest
+from enum import Enum
+from pydantic import BaseModel
+from typing import List, Optional
+from knowlang.api import ApiModelRegistry
+
+# Define models but don't register them yet
+class SampleStatus(str, Enum):
+    """Test status enum"""
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+class SampleSubModel(BaseModel):
+    """Test sub-model"""
+    name: str
+    count: int
+
+class SampleModel(BaseModel):
+    """Test model"""
+    id: int
+    status: SampleStatus
+    items: List[SampleSubModel]
+    description: Optional[str] = None
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    """Clear registry before each test"""
+    ApiModelRegistry._schemas = {}
+    yield
+    ApiModelRegistry._schemas = {}
+
+def test_register_enum():
+    """Test registering an enum"""
+    # Register the enum inside the test
+    registered_enum = ApiModelRegistry.register(SampleStatus)
+    
+    # Check if enum was registered
+    assert "SampleStatus" in ApiModelRegistry._schemas
+    
+    # Check if type information is preserved
+    assert registered_enum.ACTIVE == "active"
+    assert isinstance(registered_enum.ACTIVE, registered_enum)
+
+def test_register_model():
+    """Test registering a Pydantic model"""
+    # Register models inside the test
+    ApiModelRegistry.register(SampleStatus)
+    ApiModelRegistry.register(SampleSubModel)
+    registered_model = ApiModelRegistry.register(SampleModel)
+    
+    # Check if models were registered
+    assert "SampleModel" in ApiModelRegistry._schemas
+    assert "SampleSubModel" in ApiModelRegistry._schemas
+    
+    # Verify we can still create model instances
+    sub_item = SampleSubModel(name="test", count=1)
+    model = registered_model(
+        id=1,
+        status=SampleStatus.ACTIVE,
+        items=[sub_item]
+    )
+    assert model.id == 1
+    assert model.status == SampleStatus.ACTIVE
+
+def test_get_schema_enum():
+    """Test getting schema for enum"""
+    # Register the enum
+    ApiModelRegistry.register(SampleStatus)
+    
+    schema = ApiModelRegistry.get_schema("SampleStatus")
+    
+    assert schema["type"] == "string"
+    assert schema["enum"] == ["active", "inactive"]
+    assert schema["title"] == "SampleStatus"
+    assert schema["description"] == "Test status enum"
+
+def test_get_schema_model():
+    """Test getting schema for Pydantic model"""
+    # Register all required models
+    ApiModelRegistry.register(SampleStatus)
+    ApiModelRegistry.register(SampleSubModel)
+    ApiModelRegistry.register(SampleModel)
+    
+    schema = ApiModelRegistry.get_schema("SampleModel")
+    
+    # Check basic schema structure
+    assert schema["type"] == "object"
+    assert "properties" in schema
+    
+    # Check properties
+    props = schema["properties"]
+    assert "id" in props
+    assert "status" in props
+    assert "items" in props
+    assert "description" in props
+    
+    # Check ref format
+    assert schema["properties"]["status"]["$ref"] == "#/components/schemas/SampleStatus"
+
+def test_get_schema_not_found():
+    """Test getting schema for unregistered type"""
+    with pytest.raises(ValueError, match="Schema NotFound not registered"):
+        ApiModelRegistry.get_schema("NotFound")
+
+def test_get_all_schemas():
+    """Test getting all schemas"""
+    # Register all models
+    ApiModelRegistry.register(SampleStatus)
+    ApiModelRegistry.register(SampleSubModel)
+    ApiModelRegistry.register(SampleModel)
+    
+    schemas = ApiModelRegistry.get_all_schemas()
+    
+    # Check if all models are included
+    assert "SampleStatus" in schemas
+    assert "SampleModel" in schemas
+    assert "SampleSubModel" in schemas
+    
+    # Check schema content for one model
+    assert schemas["SampleStatus"]["type"] == "string"
+    assert schemas["SampleStatus"]["enum"] == ["active", "inactive"]


### PR DESCRIPTION
I decided not to reuse the gradio chat_interface into our frontend, however, using the chat_graph through fastapi, which has dependency with gradio


```mermaid
graph LR
    subgraph "Frontend (Next.js)"
        UI[UI Components]
        TypeDefs[Generated Types]
        SSE[SSE Client]
    end

    subgraph "Backend (FastAPI)"
        API[API Endpoints]
        ModelReg[ApiModelRegistry]
        Chat[Chat Graph]
        DB[(Vector Store)]
    end

    subgraph "Development"
        Gradio[Gradio UI]
    end

    ModelReg --> |schema| TypeDefs
    UI --> |stream| SSE
    SSE --> |request| API
    API --> |uses| Chat
    Chat --> |query| DB
    Chat --> |register types| ModelReg
    Gradio --> |debug| Chat

    classDef frontend fill:#a8d1ff,stroke:#333
    classDef backend fill:#c9e8d2,stroke:#333
    classDef dev fill:#ffd7a8,stroke:#333

    class UI,TypeDefs,SSE frontend
    class API,ModelReg,Chat,DB backend
    class Gradio dev
```