### PR TITLE
sqlite bug fix

### DIFF
--- a/settings/assets/unity/codebase.yaml
+++ b/settings/assets/unity/codebase.yaml
@@ -26,6 +26,15 @@ processor_config:
       tree_sitter_language: "csharp"
       chunk_types: ["class_definition", "function_definition"]
       max_file_size: 1_000_000
+  path_patterns:
+    exclude: [
+      "**/Library/**",
+      "**/Temp/**",
+      "**/temp/**",
+      "**/Logs/**",
+      "**/build/**",
+      "**/Build/**",
+    ]
   vector_store:
     provider: "sqlite"
     table_name: "unity_csharp"

--- a/settings/assets/unity/visualscript.yaml
+++ b/settings/assets/unity/visualscript.yaml
@@ -26,6 +26,15 @@ processor_config:
       tree_sitter_language: "unity_asset"
       chunk_types: ["group", "connection", "node"]
       max_file_size: 10_000_000 # Unity assets can be large
+  path_patterns:
+    exclude: [
+      "**/Library/**",
+      "**/Temp/**",
+      "**/temp/**",
+      "**/Logs/**",
+      "**/build/**",
+      "**/Build/**",
+    ]
   vector_store:
     provider: "sqlite"
     table_name: "visual_script"


### PR DESCRIPTION
If we have two domains accessing the same target directory, CsharpDomain and VisualSciptDomain accessing both `MyUnity/Assets/` , then the later one, exe VisualScriptDomain, can delete the one already parsed by CSharpDomain
This is not really a bug, however, should be considered as a default behavior, however, this bug exists in current implemetation of `knowlang/vector_stores/sqlite.py`, since it stores the documents in the fixed table of name `vector_documents`